### PR TITLE
Fix populating CE attributes from headers in Binary format

### DIFF
--- a/CloudEventsHttp.psm1
+++ b/CloudEventsHttp.psm1
@@ -120,12 +120,16 @@ param(
 
    if ($ContentMode -eq [CloudNative.CloudEvents.ContentMode]::Binary) {
       $bodyData = $null
+      
+      if ($cloudEvent.DataContentType -ne $null) {
+         $result.Headers.Add('Content-Type', $cloudEvent.DataContentType)
+      }
+      
       if ($cloudEvent.Data -is [byte[]]) {
          $bodyData = $cloudEvent.Data
       }
       elseif ($cloudEvent.Data -is [string]) {
          $bodyData = [System.Text.Encoding]::UTF8.GetBytes($cloudEvent.Data.ToString())
-
       }
       elseif ($cloudEvent.Data -is [IO.Stream]) {
          $buffer = New-Object 'byte[]' -ArgumentList 1024
@@ -224,7 +228,7 @@ param(
            }
 
            if ($httpHeader.Key.StartsWith($HttpHeaderPrefix, [StringComparison]::InvariantCultureIgnoreCase)) {
-               $headerValue = $httpHeader.Value
+               $headerValue = $httpHeader.Value[0]
                $name = $httpHeader.Key.Substring(3);
 
                # abolished structures in headers in 1.0

--- a/client.ps1
+++ b/client.ps1
@@ -1,5 +1,5 @@
 # Import SDK Module
-Import-Module ./CloudEventsHttp.psd1
+Import-Module (Join-Path ($PSScriptRoot | Split-Path) 'CloudEventsHttp.psd1')
 
 # 1. Create Cloud Event that produces NoContent
 $cloudEvent1 = New-CloudEvent `
@@ -15,10 +15,34 @@ $cloudEvent2 = New-CloudEvent `
                -Data @{'a'='b'} `
                -Id 'return-cloud-event'
 
-# 3. Send Cloud Events
+# 3. Send Structured Cloud Events
 $cloudEvent1, $cloudEvent2 | Foreach-Object {
    # Convert CloudEvent to HttpMessage
    $httpMessage = $_ | ConvertTo-HttpMessage -ContentMode Structured
+
+   $result = Invoke-WebRequest `
+               -Uri 'http://localhost:8080/' `
+               -Headers $httpMessage.Headers `
+               -Body $httpMessage.Body
+
+   Write-Host "Status Code: $($result.StatusCode)"
+
+   if ($result.StatusCode -eq 200) {
+      # Convert HttpMessage to CloudEvent
+      $receivedCloudEvent = ConvertFrom-HttpMessage -Headers $result.Headers -Body $result.Content
+
+      Write-Host "Cloud Event"
+      Write-Host "  Source: $($receivedCloudEvent.Source)"
+      Write-Host "  Subject: $($receivedCloudEvent.Subject)"
+      Write-Host "  Id: $($receivedCloudEvent.Id)"
+      Write-Host "  Data: $($receivedCloudEvent.Data)"
+   }
+}
+
+# 4. Send Binary Cloud Events
+$cloudEvent1, $cloudEvent2 | Foreach-Object {
+   # Convert CloudEvent to HttpMessage
+   $httpMessage = $_ | ConvertTo-HttpMessage -ContentMode Binary
 
    $result = Invoke-WebRequest `
                -Uri 'http://localhost:8080/' `

--- a/client.ps1
+++ b/client.ps1
@@ -1,5 +1,5 @@
 # Import SDK Module
-Import-Module (Join-Path ($PSScriptRoot | Split-Path) 'CloudEventsHttp.psd1')
+Import-Module ./CloudEventsHttp.psd1
 
 # 1. Create Cloud Event that produces NoContent
 $cloudEvent1 = New-CloudEvent `


### PR DESCRIPTION
Testing done
```powershell
/>CloudEventClient.ps1
Status Code: 204
Status Code: 200
Cloud Event
  Source: response:test
  Subject:
  Id: resopnse-id-1
  Data: {
  "Name": "ResponseCloudEvent"
}
Status Code: 204
Status Code: 200
Cloud Event
  Source: response:test
  Subject:
  Id: resopnse-id-1
  Data: {
  "Name": "ResponseCloudEvent"
}
/>CloudEventServer.ps1
Cloud Event
  Source: urn:test
  Subject:
  Id: test-id-1
  Data: {
  "a": "b"
}
Cloud Event
  Source: urn:test
  Subject:
  Id: return-cloud-event
  Data: {
  "a": "b"
}
Cloud Event
  Source: urn:test
  Subject:
  Id: test-id-1
  Data: 123 13 10 32 32 34 97 34 58 32 34 98 34 13 10 125
Cloud Event
  Source: urn:test
  Subject:
  Id: return-cloud-event
  Data: 123 13 10 32 32 34 97 34 58 32 34 98 34 13 10 125
```